### PR TITLE
fix: run patch-package command using npx

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test:watch": "mocha -w ./test/*.spec.js",
     "test:coverage": "cross-env NODE_ENV=test nyc mocha ./test/*.spec.js",
     "aws": "node publish.js",
-    "postinstall": "patch-package"
+    "postinstall": "npx patch-package"
   },
   "author": "Digipolis",
   "license": "MIT",


### PR DESCRIPTION
since it otherwise fails during the build:
```
error	09-Nov-2023 19:17:28	npm ERR! code 1
error	09-Nov-2023 19:17:28	npm ERR! path /data/bamboo-agent-home/xml-data/build-dir/RED-REDACTIEGISMODULEREACT-JOB1/app/node_modules/@acpaas-ui/embeddable-widgets
error	09-Nov-2023 19:17:28	npm ERR! command failed
error	09-Nov-2023 19:17:28	npm ERR! command sh -c patch-package
error	09-Nov-2023 19:17:28	npm ERR! patch-package 8.0.0
error	09-Nov-2023 19:17:28	npm ERR! Applying patches...
error	09-Nov-2023 19:17:28	npm ERR! Error: Patch file found for package zoid which is not present at node_modules/zoid
error	09-Nov-2023 19:17:28	npm ERR! ---
error	09-Nov-2023 19:17:28	npm ERR! patch-package finished with 1 error(s).
```